### PR TITLE
move description to last

### DIFF
--- a/components/status/performance.vue
+++ b/components/status/performance.vue
@@ -7,13 +7,13 @@
     </v-card-title>
     <v-card-text>
       <v-row>
-        <v-col class="text-end">
+        <v-col class="text-end" cols="5">
           <p class="label">Uptime:</p>
-          <p class="label">Load (1min):</p>
-          <p class="label">Load (5min):</p>
-          <p class="label">Load (15min):</p>
+          <p class="label">Load (1m):</p>
+          <p class="label">Load (5m):</p>
+          <p class="label">Load (15m):</p>
         </v-col>
-        <v-col>
+        <v-col cols="7">
           <!-- {{ info.loads[0] }} -->
           <p class="mb-0">{{ info.uptime }}</p>
           <p v-for="(load, index) in info.loads"

--- a/components/status/systeminfo.vue
+++ b/components/status/systeminfo.vue
@@ -19,8 +19,7 @@
           <p class="mb-0">{{ info.target_type }}</p>
           <p class="mb-0">{{ info.firmware_version }}</p>
           <p class="mb-0">{{ info.date }} {{ info.time }}</p>
-          <p class="mb-0" v-if="info.description">{{ info.description }}</p>
-          <p class="mb-0" v-else>None</p>
+          <p class="mb-0">{{ info.description }}</p>
         </v-col>
       </v-row>
     </v-card-text>

--- a/components/status/systeminfo.vue
+++ b/components/status/systeminfo.vue
@@ -8,18 +8,19 @@
     <v-card-text>
       <v-row>
         <v-col class="text-end" cols="4">
+          <p class="label">Description:</p>
           <p class="label">Model:</p>
           <p class="label">Target Type:</p>
           <p class="label">Firmware Version:</p>
           <p class="label">Node Date/time:</p>
-          <p class="label">Description:</p>
         </v-col>
         <v-col cols="8">
+          <p class="mb-0" v-if="info.description">{{ info.description }}</p>
+          <p class="mb-0" v-else>None</p>
           <p class="mb-0">{{ info.model }}</p>
           <p class="mb-0">{{ info.target_type }}</p>
           <p class="mb-0">{{ info.firmware_version }}</p>
           <p class="mb-0">{{ info.date }} {{ info.time }}</p>
-          <p class="mb-0">{{ info.description }}</p>
         </v-col>
       </v-row>
     </v-card-text>

--- a/components/status/systeminfo.vue
+++ b/components/status/systeminfo.vue
@@ -8,19 +8,19 @@
     <v-card-text>
       <v-row>
         <v-col class="text-end" cols="4">
-          <p class="label">Description:</p>
           <p class="label">Model:</p>
           <p class="label">Target Type:</p>
           <p class="label">Firmware Version:</p>
           <p class="label">Node Date/time:</p>
+          <p class="label">Description:</p>
         </v-col>
         <v-col cols="8">
-          <p class="mb-0" v-if="info.description">{{ info.description }}</p>
-          <p class="mb-0" v-else>None</p>
           <p class="mb-0">{{ info.model }}</p>
           <p class="mb-0">{{ info.target_type }}</p>
           <p class="mb-0">{{ info.firmware_version }}</p>
           <p class="mb-0">{{ info.date }} {{ info.time }}</p>
+          <p class="mb-0" v-if="info.description">{{ info.description }}</p>
+          <p class="mb-0" v-else>None</p>
         </v-col>
       </v-row>
     </v-card-text>

--- a/components/status/systeminfo.vue
+++ b/components/status/systeminfo.vue
@@ -8,18 +8,18 @@
     <v-card-text>
       <v-row>
         <v-col class="text-end" cols="4">
-          <p class="label">Description:</p>
           <p class="label">Model:</p>
           <p class="label">Target Type:</p>
           <p class="label">Firmware Version:</p>
           <p class="label">Node Date/time:</p>
+          <p class="label">Description:</p>
         </v-col>
         <v-col cols="8">
-          <p class="mb-0">{{ info.description }}</p>
           <p class="mb-0">{{ info.model }}</p>
           <p class="mb-0">{{ info.target_type }}</p>
           <p class="mb-0">{{ info.firmware_version }}</p>
           <p class="mb-0">{{ info.date }} {{ info.time }}</p>
+          <p class="mb-0">{{ info.description }}</p>
         </v-col>
       </v-row>
     </v-card-text>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -6,7 +6,7 @@
         <status-systeminfo :info="sysinfo" />
       </v-col>
       <v-col cols="4">
-        <status-performance :info="sysinfo" />
+        <status-location :info="location" />
       </v-col>
     </v-row>
     <!-- ROW 2 -->
@@ -30,7 +30,7 @@
         <status-memory :info="memory" />
       </v-col>
       <v-col cols="4">
-        <status-location :info="location" />
+        <status-performance :info="sysinfo" />
       </v-col>
     </v-row>
   </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,10 +2,10 @@
   <div>
     <!-- ROW 1 -->
     <v-row justify="center" align="stretch">
-      <v-col cols="6">
+      <v-col cols="8">
         <status-systeminfo :info="sysinfo" />
       </v-col>
-      <v-col cols="6">
+      <v-col cols="4">
         <status-performance :info="sysinfo" />
       </v-col>
     </v-row>


### PR DESCRIPTION
Make Description the last field in the System Status display. If description is first and empty, then other fields are bumped up. If description is last it avoids this issue. There may be a better solution, but this is a workaround.

### See other comments in this thread below