### PR TITLE
newui: services for non-RF nodes

### DIFF
--- a/components/nodes/neighbors.vue
+++ b/components/nodes/neighbors.vue
@@ -1,35 +1,28 @@
 <template>
   <div>
     <v-container multiple>
-      <v-row class="accent" justify="center" no-gutters>
-        <v-col cols="5">Node</v-col>
-        <v-col cols="2">IP</v-col>
+      <v-row class="accent" no-gutters>
+        <v-col cols="3">Node</v-col>
         <v-col cols="1">Type</v-col>
         <v-col cols="1">LQ</v-col>
         <v-col cols="1">NLQ</v-col>
         <v-col cols="2">Est.Thru</v-col>
+        <v-col cols="4">Services</v-col>
       </v-row>
     </v-container>
 
-    <v-expansion-panels>
-      <v-expansion-panel v-for="(node, ip) in currentNeighbors" :key="ip">
-        <v-expansion-panel-header>
-          <v-container>
-            <v-row align="start">
-              <v-col cols="5">{{ node.hostname }}</v-col>
-              <v-col cols="2">{{ ip }}</v-col>
-              <v-col cols="1">{{ node.linkType }}</v-col>
-              <v-col cols="1">{{ (node.linkQuality * 100).toFixed(0) }}%</v-col>
-              <v-col cols="1">{{ (node.neighborLinkQuality * 100).toFixed(0) }}%</v-col>
-              <v-col cols="2">{{ node.expected_throughput }}MB/s</v-col>
-            </v-row>
-          </v-container>
-        </v-expansion-panel-header>
-        <v-expansion-panel-content>
+    <v-container v-for="(node, ip) in currentNeighbors" :key="ip">
+      <v-row align="start">
+        <v-col cols="3">{{ node.hostname }}</v-col>
+        <v-col cols="1">{{ node.linkType }}</v-col>
+        <v-col cols="1">{{ (node.linkQuality * 100).toFixed(0) }}%</v-col>
+        <v-col cols="1">{{ (node.neighborLinkQuality * 100).toFixed(0) }}%</v-col>
+        <v-col cols="1">{{ node.expected_throughput }}MB/s</v-col>
+        <v-col cols="5">
           <nodes-servicechips :ip="ip" />
-        </v-expansion-panel-content>
-      </v-expansion-panel>
-    </v-expansion-panels>
+        </v-col>
+      </v-row>
+    </v-container>
   </div>
 </template>
 

--- a/components/nodes/neighbors.vue
+++ b/components/nodes/neighbors.vue
@@ -7,7 +7,7 @@
         <v-col cols="1">Type</v-col>
         <v-col cols="1">LQ</v-col>
         <v-col cols="1">NLQ</v-col>
-        <v-col cols="2">Est.Thru</v-col>
+        <v-col cols="2">Thru Mb/s</v-col>
       </v-row>
     </v-container>
 
@@ -21,7 +21,7 @@
               <v-col cols="1">{{ node.linkType }}</v-col>
               <v-col cols="1">{{ (node.linkQuality * 100).toFixed(0) }}%</v-col>
               <v-col cols="1">{{ (node.neighborLinkQuality * 100).toFixed(0) }}%</v-col>
-              <v-col cols="2">{{ node.expected_throughput }}MB/s</v-col>
+              <v-col cols="2">{{ node.linkType === "RF" ? node.expected_throughput : "n/a" }}</v-col>
             </v-row>
           </v-container>
         </v-expansion-panel-header>

--- a/components/nodes/neighbors.vue
+++ b/components/nodes/neighbors.vue
@@ -1,35 +1,28 @@
 <template>
   <div>
     <v-container multiple>
-      <v-row class="accent" justify="center" no-gutters>
-        <v-col cols="5">Node</v-col>
-        <v-col cols="2">IP</v-col>
+      <v-row class="accent" no-gutters>
+        <v-col cols="3">Node</v-col>
         <v-col cols="1">Type</v-col>
         <v-col cols="1">LQ</v-col>
         <v-col cols="1">NLQ</v-col>
         <v-col cols="2">Thru Mb/s</v-col>
+        <v-col cols="4">Services</v-col>
       </v-row>
     </v-container>
 
-    <v-expansion-panels>
-      <v-expansion-panel v-for="(node, ip) in currentNeighbors" :key="ip">
-        <v-expansion-panel-header>
-          <v-container>
-            <v-row align="start">
-              <v-col cols="5">{{ node.hostname }}</v-col>
-              <v-col cols="2">{{ ip }}</v-col>
-              <v-col cols="1">{{ node.linkType }}</v-col>
-              <v-col cols="1">{{ (node.linkQuality * 100).toFixed(0) }}%</v-col>
-              <v-col cols="1">{{ (node.neighborLinkQuality * 100).toFixed(0) }}%</v-col>
-              <v-col cols="2">{{ node.linkType === "RF" ? node.expected_throughput : "n/a" }}</v-col>
-            </v-row>
-          </v-container>
-        </v-expansion-panel-header>
-        <v-expansion-panel-content>
+    <v-container v-for="(node, ip) in currentNeighbors" :key="ip">
+      <v-row align="start">
+        <v-col cols="3">{{ node.hostname }}</v-col>
+        <v-col cols="1">{{ node.linkType }}</v-col>
+        <v-col cols="1">{{ (node.linkQuality * 100).toFixed(0) }}%</v-col>
+        <v-col cols="1">{{ (node.neighborLinkQuality * 100).toFixed(0) }}%</v-col>
+        <v-col cols="1">{{ node.linkType === "RF" ? node.expected_throughput : "n/a" }}</v-col>
+        <v-col cols="5">
           <nodes-servicechips :ip="ip" />
-        </v-expansion-panel-content>
-      </v-expansion-panel>
-    </v-expansion-panels>
+        </v-col>
+      </v-row>
+    </v-container>
   </div>
 </template>
 

--- a/components/nodes/neighbors.vue
+++ b/components/nodes/neighbors.vue
@@ -6,8 +6,8 @@
         <v-col cols="1">Type</v-col>
         <v-col cols="1">LQ</v-col>
         <v-col cols="1">NLQ</v-col>
-        <v-col cols="2">Thru Mb/s</v-col>
-        <v-col cols="4">Services</v-col>
+        <v-col cols="1">Thru Mb/s</v-col>
+        <v-col cols="5">Services</v-col>
       </v-row>
     </v-container>
 

--- a/components/nodes/neighbors.vue
+++ b/components/nodes/neighbors.vue
@@ -6,8 +6,8 @@
         <v-col cols="1">Type</v-col>
         <v-col cols="1">LQ</v-col>
         <v-col cols="1">NLQ</v-col>
-        <v-col cols="2">Est.Thru</v-col>
-        <v-col cols="4">Services</v-col>
+        <v-col cols="1">Est.Thru</v-col>
+        <v-col cols="5">Services</v-col>
       </v-row>
     </v-container>
 

--- a/components/nodes/remote.vue
+++ b/components/nodes/remote.vue
@@ -3,8 +3,9 @@
     <v-container>
       <v-row class="accent" justify="center" no-gutters>
         <v-col cols="3">Hostname</v-col>
-        <v-col cols="2">ETX</v-col>
-        <v-col cols="7">Services</v-col>
+        <v-col cols="2">IP</v-col>
+        <v-col cols="1">ETX</v-col>
+        <v-col cols="6">Services</v-col>
       </v-row>
     </v-container>
     <div v-if="$fetchState.pending">Loading...</div>
@@ -16,8 +17,9 @@
               <v-col cols="3"
                 ><a :href="makeLink(node.name)" target="_new">{{ node.name }}</a></v-col
               >
-              <v-col cols="2">{{ node.etx }}</v-col>
-              <v-col cols="7">
+              <v-col cols="2">{{ node.ip }}</v-col>
+              <v-col cols="1">{{ node.etx }}</v-col>
+              <v-col cols="6">
                 <nodes-servicechips :ip="node.ip" />
               </v-col>
             </v-row>

--- a/components/nodes/servicechips.vue
+++ b/components/nodes/servicechips.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <span v-for="(s, idx) in servicesByIp(ip)" :key="idx" v-show="servicesByIp(ip)">
-      <v-chip class="ma-1" label small link :href="s.link">
+      <v-chip class="ma-1" label small link :href="s.link" target="_blank" >
         {{ s.name }}
       </v-chip>
     </span>


### PR DESCRIPTION
This depends on arednPR#120 for the getRemRFIP function that sets IP for non-RF linked nodes. This puts all Current Neighbor information on single rows rather than expansion panels. This is one proposed solution for missing services on tunnel connected nodes (for example).