### PR TITLE
use RF IP to display service chips

### DIFF
--- a/components/nodes/neighbors.vue
+++ b/components/nodes/neighbors.vue
@@ -26,7 +26,7 @@
           </v-container>
         </v-expansion-panel-header>
         <v-expansion-panel-content>
-          <nodes-servicechips :ip="ip" />
+          <nodes-servicechips :ip="node.rfip" />
         </v-expansion-panel-content>
       </v-expansion-panel>
     </v-expansion-panels>


### PR DESCRIPTION
Use the RF IP address to display service chips on Current Neighbors for non-RF linked nodes.
This PR depends on the new "rfip" value in the api (aredn/aredn PR#124)