### PR TITLE
reverse lock icon state

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -141,8 +141,8 @@
       </v-col>
       <v-col cols="1">
         <v-btn class="mx-2" fab dark small color="primary" @click="toggleAuthenticated()">
-          <v-icon v-if="isAuthenticated()" dark> mdi-lock </v-icon>
-          <v-icon v-else dark> mdi-lock-open-variant </v-icon>
+          <v-icon v-if="isAuthenticated()" dark> mdi-lock-open-variant </v-icon>
+          <v-icon v-else dark> mdi-lock </v-icon>
         </v-btn>
       </v-col>
       <v-col cols="1">


### PR DESCRIPTION
When the UI is locked it should display only the basic features, but when unlocked it should display the configuration pages which require authentication to unlock.  (One example below)

<img width="258" alt="Screen Shot 2022-07-25 at 5 54 54 PM" src="https://user-images.githubusercontent.com/69524416/180899615-9db0d4c6-e8c2-4309-8c5a-d6ffb1a77a2c.png">